### PR TITLE
Fixed #23 frida-cycript by adding global keyword

### DIFF
--- a/lib/objc.js
+++ b/lib/objc.js
@@ -101,6 +101,8 @@ function registerTypes() {
   global.Class = classType;
   global.SEL = selectorType;
 
+  global.global = Object.keys(global);
+
   global.choose = function (className) {
     const classToFind = ObjC.classes[className];
     return ObjC.chooseSync(classToFind).map(instance => instance.toString()); 


### PR DESCRIPTION
Like the title says, this PR add supports for ```global``` keyword which used to return the message ```Target process terminated``` like in [#23](https://github.com/nowsecure/frida-cycript/issues/23) issue of frida-cycript.

Now it returns correctly all the keys present inside the global without halting it.

<img width="637" alt="Screen Shot 2021-03-26 at 9 53 30 AM" src="https://user-images.githubusercontent.com/50464613/112607206-3fc2f500-8e19-11eb-87ae-a8f127970943.png">
